### PR TITLE
manage TFS 2015

### DIFF
--- a/msbuild-artifactory-plugin/Model/Agent.cs
+++ b/msbuild-artifactory-plugin/Model/Agent.cs
@@ -12,13 +12,21 @@ namespace JFrog.Artifactory.Model
         public string name { get; set; }
         public string version { get; set; }
     
-        protected const string PRE_FIX_ENV = "buildInfo.env.";
+        internal const string PRE_FIX_ENV = "buildInfo.env.";
 
         public static Agent BuildAgentFactory(ArtifactoryBuild task) 
         {
             if (task.TfsActive != null && task.TfsActive.Equals("True"))
             {
-                return new AgentTFS(task);
+                IEnumerable<String> tfsCollectionURI = BuildEngineExtensions.GetEnvironmentVariable(task.BuildEngine, "TF_BUILD_COLLECTIONURI", false);
+                if (tfsCollectionURI != null)
+                {
+                    return new AgentTFS(task);
+                }
+                else
+                {
+                    return new AgentTFS2015(task);
+                }
             }
 
             return new AgentMSBuild(task);

--- a/msbuild-artifactory-plugin/Model/AgentTFS2015.cs
+++ b/msbuild-artifactory-plugin/Model/AgentTFS2015.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Build.Framework;
+using NuGet;
+
+namespace JFrog.Artifactory.Model
+{
+    class AgentTFS2015 : Agent
+    {
+        protected IBuildEngine buildEngine { get; set; }
+        private const string PRE_FIX_AGENT = "AGENT_";
+        private const string PRE_FIX_BUILD = "BUILD_";
+        private const string PRE_FIX_SYSTEM= "SYSTEM_";
+        public AgentTFS2015(ArtifactoryBuild task)
+        {
+            name = "TFS2015";
+            version = "";
+            buildEngine = task.BuildEngine;
+        }
+
+        public override IDictionary<string, string> BuildAgentEnvironment()
+        {
+            IDictionary<string, string> tfsProperties = BuildEngineExtensions.ContainsEnvironmentVariablesStartingWith(buildEngine, PRE_FIX_AGENT, false);
+
+            tfsProperties.AddRange(BuildEngineExtensions.ContainsEnvironmentVariablesStartingWith(buildEngine, PRE_FIX_BUILD, false));
+            tfsProperties.AddRange(BuildEngineExtensions.ContainsEnvironmentVariablesStartingWith(buildEngine, PRE_FIX_SYSTEM, false));
+
+            IDictionary<string, string> results = new Dictionary<string, string>();
+            foreach (string key in tfsProperties.Keys)
+            {
+                results.Add(PRE_FIX_ENV + key, tfsProperties[key]);
+            }
+
+            return results;
+        }
+
+        public override string BuildAgentUrl()
+        {
+            StringBuilder tfsUrl = new StringBuilder("$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)/$(SYSTEM_TEAMPROJECT)/_build#buildId=$(BUILD_BUILDID)&_a=summary");
+            IEnumerable<String> tfsCollectionURI = BuildEngineExtensions.GetEnvironmentVariable(buildEngine, "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", false);
+            IEnumerable<String> tfsTeamProject = BuildEngineExtensions.GetEnvironmentVariable(buildEngine, "SYSTEM_TEAMPROJECT", false);
+            IEnumerable<String> tfsBuildURI = BuildEngineExtensions.GetEnvironmentVariable(buildEngine, "BUILD_BUILDID", false);
+
+            if (tfsCollectionURI != null)
+                tfsUrl = tfsUrl.Replace("$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)", tfsCollectionURI.First());
+
+            if (tfsTeamProject != null)
+                tfsUrl = tfsUrl.Replace("$(SYSTEM_TEAMPROJECT)", tfsTeamProject.First());
+
+            if (tfsBuildURI != null)
+                tfsUrl = tfsUrl.Replace("$(BUILD_BUILDID)", tfsBuildURI.First());
+
+            return tfsUrl.ToString();
+        }
+    }
+}

--- a/msbuild-artifactory-plugin/Utils/BuildEngineExtensions.cs
+++ b/msbuild-artifactory-plugin/Utils/BuildEngineExtensions.cs
@@ -99,14 +99,14 @@ namespace JFrog.Artifactory
         private static ProjectInstance GetProjectInstance(IBuildEngine buildEngine)
         {
             var buildEngineType = buildEngine.GetType();
-            var targetBuilderCallbackField = buildEngineType.GetField("targetBuilderCallback", bindingFlags);
+            var targetBuilderCallbackField = buildEngineType.GetField("targetBuilderCallback", bindingFlags) ?? buildEngineType.GetField("_targetBuilderCallback", bindingFlags);
             if (targetBuilderCallbackField == null)
             {
                 throw new Exception("Could not extract targetBuilderCallback from " + buildEngineType.FullName);
             }
             var targetBuilderCallback = targetBuilderCallbackField.GetValue(buildEngine);
             var targetCallbackType = targetBuilderCallback.GetType();
-            var projectInstanceField = targetCallbackType.GetField("projectInstance", bindingFlags);
+            var projectInstanceField = targetCallbackType.GetField("projectInstance", bindingFlags) ?? targetCallbackType.GetField("_projectInstance", bindingFlags);
             if (projectInstanceField == null)
             {
                 throw new Exception("Could not extract projectInstance from " + targetCallbackType.FullName);

--- a/msbuild-artifactory-plugin/Utils/BuildEngineExtensions.cs
+++ b/msbuild-artifactory-plugin/Utils/BuildEngineExtensions.cs
@@ -77,6 +77,25 @@ namespace JFrog.Artifactory
             return new Dictionary<string, string>();
         }
 
+        public static IDictionary<string, string> ContainsEnvironmentVariablesStartingWith(this IBuildEngine buildEngine, string key, bool throwIfNotFound)
+        {
+            var projectInstance = GetProjectInstance(buildEngine);
+
+            var properties = projectInstance.Properties
+                .Where(x => x.Name.ToLower().StartsWith(key.ToLower())).ToDictionary(x => x.Name, x => x.EvaluatedValue);
+            if (properties.Count > 0)
+            {
+                return properties;
+            }
+
+            if (throwIfNotFound)
+            {
+                throw new Exception(string.Format("Could not extract from '{0}' environmental variables.", key));
+            }
+
+            return new Dictionary<string, string>();
+        }
+
         private static ProjectInstance GetProjectInstance(IBuildEngine buildEngine)
         {
             var buildEngineType = buildEngine.GetType();

--- a/msbuild-artifactory-plugin/Utils/BuildInfoExtractor.cs
+++ b/msbuild-artifactory-plugin/Utils/BuildInfoExtractor.cs
@@ -179,15 +179,17 @@ namespace JFrog.Artifactory.Utils
             IDictionary sysVariables = Environment.GetEnvironmentVariables(EnvironmentVariableTarget.Process);
             var dicVariables = new Dictionary<string, string>();
 
+            var environmentVariables = build.agent.BuildAgentEnvironment();
+
             foreach(string key in sysVariables.Keys)
             {
-                if (!PathConflicts(includePatterns, excludePatterns, includeRegex, excludeRegex, key)) 
+                if (!environmentVariables.ContainsKey(string.Concat(Agent.PRE_FIX_ENV, key)) && !PathConflicts(includePatterns, excludePatterns, includeRegex, excludeRegex, key)) 
                 {
                     dicVariables.Add(key, (string)sysVariables[key]);
                 }
             }
 
-            dicVariables.AddRange(build.agent.BuildAgentEnvironment());
+            dicVariables.AddRange(environmentVariables);
 
             build.properties = dicVariables;
         }

--- a/msbuild-artifactory-plugin/msbuild-artifactory-plugin.csproj
+++ b/msbuild-artifactory-plugin/msbuild-artifactory-plugin.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Model\Agent.cs" />
     <Compile Include="Model\AgentMSBuild.cs" />
     <Compile Include="Model\AgentTFS.cs" />
+    <Compile Include="Model\AgentTFS2015.cs" />
     <Compile Include="Utils\BuildEngineExtensions.cs" />
     <Compile Include="Model\ArtifactoryBuildInfoClient.cs" />
     <Compile Include="Model\ArtifactoryConfig.cs" />


### PR DESCRIPTION
These changes allow the plugin to handle TFS2015 and VSO environment variables (no more prefixed by "TF_"). Also fixed duplicate values in system and environment variables in build info (a variable added as environment will no more be added as a system variable).
